### PR TITLE
Break circular reference

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -6,7 +6,9 @@ services:
 
     tactician_domain_events.dispatcher:
         class: BornFree\TacticianDomainEvent\EventDispatcher\EventDispatcher
-
+        lazy: true
+        
     tactician_domain_events.middleware.release_recorded_events:
         class: BornFree\TacticianDomainEvent\Middleware\ReleaseRecordedEventsMiddleware
         arguments: ['@tactician_domain_events.doctrine.event_collector', '@tactician_domain_events.dispatcher']
+        lazy: true


### PR DESCRIPTION
These services could be marked as lazy, this change is solving problem with DI circular reference chain.

[About lazy services](http://symfony.com/doc/current/service_container/lazy_services.html)

Before this change we was not able to inject `\League\Tactician\CommandBus` to our event listeners due to DI circular reference detection. 

**Exception message:**
```
Circular reference detected for service "tactician.commandbus.default", path: "tactician.commandbus.default -> tactician_domain_events.middleware.release_recorded_events -> tactician_domain_events.dispatcher -> app.subscriber.domain_object_was_created". (Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException)
```

@borNfreee What do you think about this simple solution?