### PR TITLE
Add debug command for domain events

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ class User implements ContainsRecordedEvents
 
 As soon as this `Entity` is successfully created, the `SendEmailAfterUserIsCreatedListener` will be triggered.
 
+### Debugging
+
+You can run the `debug:tactician-domain-events` command to get a list of all events with mapped listeners.
+
 License
 -------
 

--- a/src/Command/DebugCommand.php
+++ b/src/Command/DebugCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace BornFree\TacticianDomainEventBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class DebugCommand extends Command
+{
+    /**
+     * @var array
+     */
+    private $mappings;
+
+    public function __construct(array $mappings)
+    {
+        parent::__construct();
+
+        $this->mappings = $mappings;
+    }
+
+    protected function configure()
+    {
+        $this->setName('debug:tactician-domain-events');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $io->title('Tactician domain events');
+        $headers = ['Order', 'Callable'];
+
+        foreach ($this->mappings as $event => $listeners) {
+            $io->section('Event: '.$event);
+            $io->table($headers, $this->mappingToRows($listeners));
+        }
+
+        $io->comment('Number of events: '. count($this->mappings));
+    }
+
+    private function mappingToRows(array $listeners)
+    {
+        $rows = [];
+        foreach ($listeners as $idx => $listener) {
+            $rows[] = ['#'.($idx+1), $listener];
+        }
+
+        return $rows;
+    }
+}

--- a/src/DependencyInjection/Compiler/PopulateDebugCommandPass.php
+++ b/src/DependencyInjection/Compiler/PopulateDebugCommandPass.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace BornFree\TacticianDomainEventBundle\DependencyInjection\Compiler;
+
+use BornFree\TacticianDomainEvent\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class PopulateDebugCommandPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('tactician_domain_events.command.debug')) {
+            return;
+        }
+
+        $command = $container->getDefinition('tactician_domain_events.command.debug');
+        $subscribers = $container->findTaggedServiceIds('tactician.event_subscriber');
+        $listeners = $container->findTaggedServiceIds('tactician.event_listener');
+
+        $events = [];
+
+        foreach ($listeners as $serviceId => $tags) {
+            foreach ($tags as $tag) {
+                $listener = $container->getDefinition($serviceId);
+                $events[$tag['event']][] = $listener->getClass().'::'.$tag['method'];
+            }
+        }
+
+        foreach ($subscribers as $serviceId => $tags) {
+            $subscriber = $container->get($serviceId);
+
+            if (!$subscriber instanceof EventSubscriberInterface) {
+                continue;
+            }
+
+            foreach ($subscriber->getSubscribedEvents() as $event => $method) {
+                $events[$event][] = get_class($subscriber).'::'.$method;
+            }
+        }
+
+        ksort($events);
+        $command->setArgument(0, $events);
+    }
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -12,3 +12,8 @@ services:
         class: BornFree\TacticianDomainEvent\Middleware\ReleaseRecordedEventsMiddleware
         arguments: ['@tactician_domain_events.doctrine.event_collector', '@tactician_domain_events.dispatcher']
         lazy: true
+
+    tactician_domain_events.command.debug:
+        class: BornFree\TacticianDomainEventBundle\Command\DebugCommand
+        tags:
+            - { name: console.command }

--- a/src/TacticianDomainEventBundle.php
+++ b/src/TacticianDomainEventBundle.php
@@ -2,9 +2,14 @@
 
 namespace BornFree\TacticianDomainEventBundle;
 
+use BornFree\TacticianDomainEventBundle\DependencyInjection\Compiler\PopulateDebugCommandPass;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class TacticianDomainEventBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new PopulateDebugCommandPass());
+    }
 }


### PR DESCRIPTION
Sometimes with many domain events is hard to keep track on all of them. In Tactitian Bundle we have a debug command for all commands, so here we have a command to print all domain events with listeners.