### PR TITLE
Change phase when PopulateDebugCommandPass is executed

### DIFF
--- a/src/TacticianDomainEventBundle.php
+++ b/src/TacticianDomainEventBundle.php
@@ -3,6 +3,7 @@
 namespace BornFree\TacticianDomainEventBundle;
 
 use BornFree\TacticianDomainEventBundle\DependencyInjection\Compiler\PopulateDebugCommandPass;
+use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -10,6 +11,6 @@ class TacticianDomainEventBundle extends Bundle
 {
     public function build(ContainerBuilder $container)
     {
-        $container->addCompilerPass(new PopulateDebugCommandPass());
+        $container->addCompilerPass(new PopulateDebugCommandPass(), PassConfig::TYPE_OPTIMIZE);
     }
 }


### PR DESCRIPTION
Without this change autowiring for EventListenerInterface and EventSubscriberInterface won't work - autowired services won't have their arguments at that moment to be able to be constructed.

Fixes #5 