### PR TITLE
Remove deprecation

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -9,8 +9,8 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('tactician_domain_event');
+        $treeBuilder = new TreeBuilder('tactician_domain_event');
+        $rootNode = method_exists(TreeBuilder::class, 'getRootNode') ? $treeBuilder->getRootNode() : $treeBuilder->root('tactician_domain_event');
 
         $rootNode
             ->children()


### PR DESCRIPTION
A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.