### PR TITLE
Register listener events using typehints

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,43 @@ class User implements ContainsRecordedEvents
     // ...
 }
 ```
-
 As soon as this `Entity` is successfully created, the `SendEmailAfterUserIsCreatedListener` will be triggered.
 
+### Map Based On Typehints
+Rather than repeating the command's full class name, we can also reflect on the Handler's method typehints.
+
+```yaml
+app.listener.send_email:
+    class: AppBundle\EventListener\SendEmailAfterUserIsCreatedListener
+    tags:
+        - { name: tactician.event_listener, typhints: true }
+```
+
+This detects what commands this handler receives by inspecting the class' methods. The rules for matching are:
+
+1. The method must be public.
+2. The method must accept only one parameter.
+3. The parameter must be typehinted with a class name.
+
+If you have multiple commands going into a single handler, they will all be detected, provided they follow the rules above. The actual name of the method is NOT important.
+
+In other words, the SendEmailAfterUserIsCreatedListener class should look like this:
+
+```php
+<?php
+class SendEmailAfterUserIsCreatedListener
+{
+    public function handleRegisterUser(RegisterUser $command)
+    {
+       // do stuff
+    }
+    
+    public function handleUserWasCreated(UserWasCreated $command)
+    {
+       // do stuff
+    }
+}
+```
 ### Debugging
 
 You can run the `debug:tactician-domain-events` command to get a list of all events with mapped listeners.

--- a/src/DependencyInjection/TacticianDomainEventExtension.php
+++ b/src/DependencyInjection/TacticianDomainEventExtension.php
@@ -2,6 +2,7 @@
 
 namespace BornFree\TacticianDomainEventBundle\DependencyInjection;
 
+use ReflectionClass;
 use BornFree\TacticianDoctrineDomainEvent\EventListener\CollectsEventsFromAllEntitiesManagedByUnitOfWork;
 use BornFree\TacticianDoctrineDomainEvent\EventListener\CollectsEventsFromEntities;
 use Symfony\Component\DependencyInjection\Definition;
@@ -40,32 +41,98 @@ class TacticianDomainEventExtension extends Extension implements CompilerPassInt
         $definition = $container->getDefinition('tactician_domain_events.dispatcher');
         $taggedServices = $container->findTaggedServiceIds('tactician.event_listener');
 
+        $listeners = array_merge(
+            $this->findListenersForEvent($taggedServices),
+            $this->findListenersForTypeHints($container, $taggedServices)
+        );
+
+        foreach($listeners as $item) {
+            if (!class_exists($item['event'])) {
+                throw new \Exception(
+                    sprintf(
+                        'Class %s registered as an event class in %s does not exist',
+                        $item['event'],
+                        $item['id']
+                    )
+                );
+            }
+
+            $listener = $item['method']
+                ? [new Reference($item['id']), $item['method']]
+                : new Reference($item['id']);
+
+            $definition->addMethodCall('addListener', [
+                $item['event'],
+                $listener
+            ]);
+
+        }
+    }
+
+    private function findListenersForEvent($taggedServices): array
+    {
+        $listeners = [];
+
         foreach ($taggedServices as $id => $tags) {
             foreach ($tags as $attributes) {
                 if (!isset($attributes['event'])) {
-                    throw new \Exception('The tactician.event_listener tag must always have an event attribute');
+                    continue;
                 }
 
-                if (!class_exists($attributes['event'])) {
-                    throw new \Exception(
-                        sprintf(
-                            'Class %s registered as an event class in %s does not exist',
-                            $attributes['event'],
-                            $id
-                        )
-                    );
-                }
-
-                $listener = array_key_exists('method', $attributes)
-                    ? [new Reference($id), $attributes['method']]
-                    : new Reference($id);
-
-                $definition->addMethodCall('addListener', [
-                    $attributes['event'],
-                    $listener
-                ]);
+                $listeners[] = [
+                    'id'     => $id,
+                    'event'  => $attributes['event'],
+                    'method' => $attributes['method'] ?? null
+                ];               
             }
         }
+
+        return $listeners;
+    }
+
+    private function findListenersForTypeHints(ContainerBuilder $container, $taggedServices): array
+    {
+        $listeners = [];
+
+        foreach ($taggedServices as $id => $tags) {
+            foreach ($tags as $attributes) {
+                if (!isset($attributes['typehints']) || $attributes['typehints'] !== true) {
+                    continue;
+                }
+
+                $reflClass = new ReflectionClass($container->getParameterBag()->resolveValue($container->getDefinition($id)->getClass()));
+
+                foreach ($reflClass->getMethods() as $method) {
+                    if (!$method->isPublic()
+                        || $method->isConstructor()
+                        || $method->isStatic()
+                        || $method->isAbstract()
+                        || $method->isVariadic()
+                        || $method->getNumberOfParameters() !== 1
+                    ) {
+                        continue;
+                    }
+                    $parameter = $method->getParameters()[0];
+                    // dump($parameter);
+                    if (!$parameter->hasType()
+                        || $parameter->getType()->isBuiltin()
+                        || $parameter->getClass()->isInterface()
+                    ) {
+                        continue;
+                    }
+
+                    $event = (string)$parameter->getType();
+
+                    $listeners[] = [
+                        'id'     => $id,
+                        'event'  => $event,
+                        'method' => $method->getName()
+                    ];               
+                }
+            }
+        }
+
+        return $listeners;
     }
 
     private function addSubscribers(ContainerBuilder $container)

--- a/src/DependencyInjection/TacticianDomainEventExtension.php
+++ b/src/DependencyInjection/TacticianDomainEventExtension.php
@@ -50,7 +50,7 @@ class TacticianDomainEventExtension extends Extension implements CompilerPassInt
             if (!class_exists($item['event'])) {
                 throw new \Exception(
                     sprintf(
-                        'Class %s registered as an event class in %s does not exist',
+                        'Class "%s" registered as an event class in "%s" does not exist',
                         $item['event'],
                         $item['id']
                     )
@@ -113,7 +113,6 @@ class TacticianDomainEventExtension extends Extension implements CompilerPassInt
                         continue;
                     }
                     $parameter = $method->getParameters()[0];
-                    // dump($parameter);
                     if (!$parameter->hasType()
                         || $parameter->getType()->isBuiltin()
                         || $parameter->getClass()->isInterface()


### PR DESCRIPTION
Hello,

I think it would be interesting to be able to define the event that a listener will execute by means of typehints.

I hope that the code will serve you at least as a test.

```yaml
my.listener:
    class: App\Listener\\MyListener
    tags:
        - { name: tactician.event_listener, typehints: true }
```
